### PR TITLE
Hotfix: Refatoracao/command exceptions

### DIFF
--- a/Includes/Classes/Iterator/Iterator.hpp
+++ b/Includes/Classes/Iterator/Iterator.hpp
@@ -28,7 +28,7 @@ public:
    * elemetos, aponta-se para o própro sentinela
    */
   void nextInRow();
-  
+
   /**
    * @brief Sobrecarga do operador igualdade
    *

--- a/Includes/CommandPattern/Invoker/InvokerCommand.hpp
+++ b/Includes/CommandPattern/Invoker/InvokerCommand.hpp
@@ -7,9 +7,9 @@
 
 #include "../../../Defs/CommandInfo.hpp"
 #include "../../../Defs/UnorderedMapCommand.hpp"
-#include "../Commands/HelpCommand.hpp"
-#include "../../Exceptions/InvalidCommandException.hpp"
 #include "../../../Includes/Messages/Messages.hpp"
+#include "../../Exceptions/InvalidCommandException.hpp"
+#include "../Commands/HelpCommand.hpp"
 
 using Context = std::function<ContextCommand *()>;
 

--- a/Includes/CommandPattern/Invoker/InvokerCommand.hpp
+++ b/Includes/CommandPattern/Invoker/InvokerCommand.hpp
@@ -8,6 +8,8 @@
 #include "../../../Defs/CommandInfo.hpp"
 #include "../../../Defs/UnorderedMapCommand.hpp"
 #include "../Commands/HelpCommand.hpp"
+#include "../../Exceptions/InvalidCommandException.hpp"
+#include "../../../Includes/Messages/Messages.hpp"
 
 using Context = std::function<ContextCommand *()>;
 

--- a/Includes/Exceptions/InvalidColumnException.hpp
+++ b/Includes/Exceptions/InvalidColumnException.hpp
@@ -6,8 +6,7 @@
 
 class InvalidColumnException : public std::runtime_error {
 public:
-    explicit InvalidColumnException(const std::string& message)
-        : std::runtime_error(message) {}
+    explicit InvalidColumnException(const std::string& message);
 };
 
 #endif

--- a/Includes/Exceptions/InvalidColumnException.hpp
+++ b/Includes/Exceptions/InvalidColumnException.hpp
@@ -6,7 +6,7 @@
 
 class InvalidColumnException : public std::runtime_error {
 public:
-    explicit InvalidColumnException(const std::string& message);
+  explicit InvalidColumnException(const std::string &message);
 };
 
 #endif

--- a/Includes/Exceptions/InvalidColumnException.hpp
+++ b/Includes/Exceptions/InvalidColumnException.hpp
@@ -6,6 +6,11 @@
 
 class InvalidColumnException : public std::runtime_error {
 public:
+  /**
+   * @brief Cria uma exceção de coluna inválida
+   * 
+   * @param message Mensagem a ser exibida
+   */
   explicit InvalidColumnException(const std::string &message);
 };
 

--- a/Includes/Exceptions/InvalidCommandException.hpp
+++ b/Includes/Exceptions/InvalidCommandException.hpp
@@ -1,0 +1,12 @@
+#ifndef INVALID_COMMAND_EXCEPTION_HPP
+#define INVALID_COMMAND_EXCEPTION_HPP
+
+#include <stdexcept>
+#include <string>
+
+class InvalidCommandException : public std::runtime_error {
+public:
+    explicit InvalidCommandException(const std::string& message);
+};
+
+#endif

--- a/Includes/Exceptions/InvalidCommandException.hpp
+++ b/Includes/Exceptions/InvalidCommandException.hpp
@@ -6,6 +6,11 @@
 
 class InvalidCommandException : public std::runtime_error {
 public:
+  /**
+   * @brief Cria uma exceção de comando inválido
+   * 
+   * @param message Mensagem a ser exibida
+   */
   explicit InvalidCommandException(const std::string &message);
 };
 

--- a/Includes/Exceptions/InvalidCommandException.hpp
+++ b/Includes/Exceptions/InvalidCommandException.hpp
@@ -6,7 +6,7 @@
 
 class InvalidCommandException : public std::runtime_error {
 public:
-    explicit InvalidCommandException(const std::string& message);
+  explicit InvalidCommandException(const std::string &message);
 };
 
 #endif

--- a/Includes/Exceptions/InvalidRowException.hpp
+++ b/Includes/Exceptions/InvalidRowException.hpp
@@ -6,6 +6,11 @@
 
 class InvalidRowException : public std::runtime_error {
 public:
+  /**
+   * @brief Cria uma exceção de linha inválida
+   * 
+   * @param message Mensagem a ser exibida
+   */
   explicit InvalidRowException(const std::string &message);
 };
 

--- a/Includes/Exceptions/InvalidRowException.hpp
+++ b/Includes/Exceptions/InvalidRowException.hpp
@@ -6,8 +6,7 @@
 
 class InvalidRowException : public std::runtime_error {
 public:
-    explicit InvalidRowException(const std::string& message)
-        : std::runtime_error(message) {}
+    explicit InvalidRowException(const std::string& message);
 };
 
 #endif

--- a/Includes/Exceptions/InvalidRowException.hpp
+++ b/Includes/Exceptions/InvalidRowException.hpp
@@ -6,7 +6,7 @@
 
 class InvalidRowException : public std::runtime_error {
 public:
-    explicit InvalidRowException(const std::string& message);
+  explicit InvalidRowException(const std::string &message);
 };
 
 #endif

--- a/Includes/Messages/Messages.hpp
+++ b/Includes/Messages/Messages.hpp
@@ -1,0 +1,24 @@
+#ifndef MESSAGES_HPP
+#define MESSAGES_HPP
+
+#include <string>
+#include <sstream>
+
+// Mensagens que são lançadas por exeptions
+namespace Messages {
+    std::string invalidRowMessage(int row);
+
+    std::string invalidColumnMessage(int col);
+
+    std::string colNegative(int col);
+
+    std::string rowNegative(int row);
+
+    std::string colZero();
+
+    std::string rowZero();
+    
+    std::string invalidCommandMessage();
+}
+
+#endif

--- a/Includes/Messages/Messages.hpp
+++ b/Includes/Messages/Messages.hpp
@@ -6,18 +6,47 @@
 
 // Mensagens que são lançadas por exeptions
 namespace Messages {
+/**
+ * @brief Mensagem de linha inválida
+ * 
+ * @param row Número da linha
+ */
 std::string invalidRowMessage(int row);
 
+/**
+ * @brief Mensagem de coluna inválida
+ * 
+ * @param col Número da coluna
+ */
 std::string invalidColumnMessage(int col);
 
+/**
+ * @brief Mensagem de coluna negativa
+ * 
+ * @param col Número da coluna
+ */
 std::string colNegative(int col);
 
+/**
+ * @brief Mensagem de linha negativa
+ * 
+ * @param row Número da linha
+ */
 std::string rowNegative(int row);
 
+/**
+ * @brief Mensagem de coluna nula
+ */
 std::string colZero();
 
+/**
+ * @brief Mensagem de coluna zero
+ */
 std::string rowZero();
 
+/**
+ * @brief Mensagem de comando inválido
+ */
 std::string invalidCommandMessage();
 } // namespace Messages
 

--- a/Includes/Messages/Messages.hpp
+++ b/Includes/Messages/Messages.hpp
@@ -1,24 +1,24 @@
 #ifndef MESSAGES_HPP
 #define MESSAGES_HPP
 
-#include <string>
 #include <sstream>
+#include <string>
 
 // Mensagens que são lançadas por exeptions
 namespace Messages {
-    std::string invalidRowMessage(int row);
+std::string invalidRowMessage(int row);
 
-    std::string invalidColumnMessage(int col);
+std::string invalidColumnMessage(int col);
 
-    std::string colNegative(int col);
+std::string colNegative(int col);
 
-    std::string rowNegative(int row);
+std::string rowNegative(int row);
 
-    std::string colZero();
+std::string colZero();
 
-    std::string rowZero();
-    
-    std::string invalidCommandMessage();
-}
+std::string rowZero();
+
+std::string invalidCommandMessage();
+} // namespace Messages
 
 #endif

--- a/Includes/Utils/Validation/Validation.hpp
+++ b/Includes/Utils/Validation/Validation.hpp
@@ -1,9 +1,9 @@
 #ifndef VALIDATION_UTILS_HPP
 #define VALIDATION_UTILS_HPP
 
-#include "../../../Messages/Messages.hpp"
-#include "../../../Exceptions/InvalidColumnException.hpp"
-#include "../../../Exceptions/InvalidRowException.hpp"
+#include "../../../Includes/Messages/Messages.hpp"
+#include "../../Exceptions/InvalidColumnException.hpp"
+#include "../../Exceptions/InvalidRowException.hpp"
 #include "../../../Includes/Classes/Node/Node.hpp"
 
 // serve para a validação antes da criação da matriz 

--- a/Includes/Utils/Validation/Validation.hpp
+++ b/Includes/Utils/Validation/Validation.hpp
@@ -8,12 +8,20 @@
 
 // serve para a validação antes da criação da matriz
 namespace ValidationUtils {
-// faz a verificação da linha e coluna
-// antes da criação da matriz
+/**
+ * @brief Faz a verificação de linha e coluna antes da criação da matrix
+ * 
+ * @param row Número da linha
+ * @param col Número da coluna
+ */
 void verifyRowCol(int row, int col);
 
-// faz verificação se Node é Valido
-// vai ser implementado
+/**
+ * @brief Faz verificação se Node é válido
+ * 
+ * @param row Número da linha
+ * @param col Número da coluna
+ */
 void verifyValidRowCol(int row, int col);
 } // namespace ValidationUtils
 

--- a/Includes/Utils/Validation/Validation.hpp
+++ b/Includes/Utils/Validation/Validation.hpp
@@ -1,20 +1,20 @@
 #ifndef VALIDATION_UTILS_HPP
 #define VALIDATION_UTILS_HPP
 
+#include "../../../Includes/Classes/Node/Node.hpp"
 #include "../../../Includes/Messages/Messages.hpp"
 #include "../../Exceptions/InvalidColumnException.hpp"
 #include "../../Exceptions/InvalidRowException.hpp"
-#include "../../../Includes/Classes/Node/Node.hpp"
 
-// serve para a validação antes da criação da matriz 
+// serve para a validação antes da criação da matriz
 namespace ValidationUtils {
-    // faz a verificação da linha e coluna
-    // antes da criação da matriz
-    void verifyRowCol(int row, int col);
+// faz a verificação da linha e coluna
+// antes da criação da matriz
+void verifyRowCol(int row, int col);
 
-    // faz verificação se Node é Valido 
-    // vai ser implementado
-    void verifyValidRowCol(int row, int col);
-}
+// faz verificação se Node é Valido
+// vai ser implementado
+void verifyValidRowCol(int row, int col);
+} // namespace ValidationUtils
 
 #endif

--- a/Main.cpp
+++ b/Main.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <string>
+#include <exception>
 
 #include "Includes/CommandPattern/Invoker/InvokerCommand.hpp"
 // #include "Includes/CommandPattern/Commands/TestCommand.hpp"
@@ -12,16 +13,22 @@ int main() {
   // invoker.registerCommand(testCommand.getName(), &testCommand);
 
   while (true) {
-    std::string input;
-    std::getline(std::cin, input);
+    try {
+      std::string input;
+      std::getline(std::cin, input);
 
-    if (input == "help") {
-      invoker.showHelp();
-    } else if (input == "exit") {
-      break;
-    } else {
-      invoker.executeCommand(input);
+      if (input == "help") {
+        invoker.showHelp();
+      } else if (input == "exit") {
+        break;
+      } else {
+        invoker.executeCommand(input);
+      }
+    } catch (const std::exception& e) {
+      std::cout << e.what() << " haha\n";
     }
+
+
   }
 
   std::cout << "Até mais!" << std::endl;

--- a/Main.cpp
+++ b/Main.cpp
@@ -1,6 +1,6 @@
+#include <exception>
 #include <iostream>
 #include <string>
-#include <exception>
 
 #include "Includes/CommandPattern/Invoker/InvokerCommand.hpp"
 // #include "Includes/CommandPattern/Commands/TestCommand.hpp"
@@ -24,11 +24,9 @@ int main() {
       } else {
         invoker.executeCommand(input);
       }
-    } catch (const std::exception& e) {
+    } catch (const std::exception &e) {
       std::cout << e.what() << " haha\n";
     }
-
-
   }
 
   std::cout << "Até mais!" << std::endl;

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,10 @@ SRC = Src
 BIN = Bin
 
 # Objetos
-OBJ = $(BIN)/Node.o $(BIN)/Iterator.o $(BIN)/HelpCommand.o $(BIN)/Invoker.o $(BIN)/Main.o
+OBJ = $(BIN)/Node.o $(BIN)/Iterator.o $(BIN)/HelpCommand.o $(BIN)/Invoker.o $(BIN)/Validation.o $(BIN)/Messages.o $(BIN)/Main.o $(BIN)/InvalidColumnException.o $(BIN)/InvalidRowException.o $(BIN)/InvalidCommandException.o
 CLASSES = $(SRC)/Classes
 COMMAND_PATTERN = $(SRC)/CommandPattern
+UTILS = $(SRC)/Utils
 
 # Regra padrão para a targt definida no final
 all: app
@@ -31,6 +32,22 @@ $(BIN)/Node.o: $(CLASSES)/Node/Node.cpp
 
 $(BIN)/Iterator.o: $(CLASSES)/Iterator/Iterator.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDETAGS) -c $< -o $@
+
+$(BIN)/Validation.o: $(UTILS)/Validation/Validation.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDETAGS) -c $< -o $@
+
+$(BIN)/Messages.o: $(SRC)/Messages/Messages.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDETAGS) -c $< -o $@
+
+$(BIN)/InvalidColumnException.o: $(SRC)/Exceptions/InvalidColumnException.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDETAGS) -c $< -o $@
+
+$(BIN)/InvalidCommandException.o: $(SRC)/Exceptions/InvalidCommandException.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDETAGS) -c $< -o $@
+
+$(BIN)/InvalidRowException.o: $(SRC)/Exceptions/InvalidRowException.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDETAGS) -c $< -o $@
+
 
 # $(BIN)/teste.o: test.cpp
 # 	$(CXX) $(CXXFLAGS) -c $< -o $@

--- a/Src/CommandPattern/Invoker/InvokerCommand.cpp
+++ b/Src/CommandPattern/Invoker/InvokerCommand.cpp
@@ -10,7 +10,8 @@ void InvokerCommand::registerCommand(const std::string &commandName,
 }
 
 void InvokerCommand::executeCommand(const std::string &commandName) {
-  if (commandRegistry.find(commandName) == commandRegistry.end()) throw InvalidCommandException(Messages::invalidCommandMessage());
+  if (commandRegistry.find(commandName) == commandRegistry.end())
+    throw InvalidCommandException(Messages::invalidCommandMessage());
 
   CommandInfo &info = commandRegistry[commandName];
   ContextCommand *context = info.contextFactory();

--- a/Src/CommandPattern/Invoker/InvokerCommand.cpp
+++ b/Src/CommandPattern/Invoker/InvokerCommand.cpp
@@ -10,12 +10,7 @@ void InvokerCommand::registerCommand(const std::string &commandName,
 }
 
 void InvokerCommand::executeCommand(const std::string &commandName) {
-  if (commandRegistry.find(commandName) == commandRegistry.end()) {
-    std::cout << "Comando inválido! Use o comando 'help' para listar todos os "
-                 "comandos"
-              << std::endl;
-    return;
-  }
+  if (commandRegistry.find(commandName) == commandRegistry.end()) throw InvalidCommandException(Messages::invalidCommandMessage());
 
   CommandInfo &info = commandRegistry[commandName];
   ContextCommand *context = info.contextFactory();

--- a/Src/Exceptions/InvalidColumnException.cpp
+++ b/Src/Exceptions/InvalidColumnException.cpp
@@ -1,3 +1,4 @@
 #include "../../Includes/Exceptions/InvalidColumnException.hpp"
 
-InvalidColumnException::InvalidColumnException(const std::string& message): std::runtime_error(message) {}
+InvalidColumnException::InvalidColumnException(const std::string &message)
+    : std::runtime_error(message) {}

--- a/Src/Exceptions/InvalidColumnException.cpp
+++ b/Src/Exceptions/InvalidColumnException.cpp
@@ -1,0 +1,3 @@
+#include "../../Includes/Exceptions/InvalidColumnException.hpp"
+
+InvalidColumnException::InvalidColumnException(const std::string& message): std::runtime_error(message) {}

--- a/Src/Exceptions/InvalidCommandException.cpp
+++ b/Src/Exceptions/InvalidCommandException.cpp
@@ -1,0 +1,3 @@
+#include "../../Includes/Exceptions/InvalidCommandException.hpp"
+
+InvalidCommandException::InvalidCommandException(const std::string& message) : std::runtime_error(message) {}

--- a/Src/Exceptions/InvalidCommandException.cpp
+++ b/Src/Exceptions/InvalidCommandException.cpp
@@ -1,3 +1,4 @@
 #include "../../Includes/Exceptions/InvalidCommandException.hpp"
 
-InvalidCommandException::InvalidCommandException(const std::string& message) : std::runtime_error(message) {}
+InvalidCommandException::InvalidCommandException(const std::string &message)
+    : std::runtime_error(message) {}

--- a/Src/Exceptions/InvalidRowException.cpp
+++ b/Src/Exceptions/InvalidRowException.cpp
@@ -1,3 +1,4 @@
 #include "../../Includes/Exceptions/InvalidRowException.hpp"
 
-InvalidRowException::InvalidRowException(const std::string& message): std::runtime_error(message) {}
+InvalidRowException::InvalidRowException(const std::string &message)
+    : std::runtime_error(message) {}

--- a/Src/Exceptions/InvalidRowException.cpp
+++ b/Src/Exceptions/InvalidRowException.cpp
@@ -1,0 +1,3 @@
+#include "../../Includes/Exceptions/InvalidRowException.hpp"
+
+InvalidRowException::InvalidRowException(const std::string& message): std::runtime_error(message) {}

--- a/Src/Messages/Messages.cpp
+++ b/Src/Messages/Messages.cpp
@@ -1,39 +1,35 @@
 #include "../../Includes/Messages/Messages.hpp"
 
 namespace Messages {
-    std::string invalidRowMessage(int row) {
-        std::ostringstream os;
-        os << "Linha invalida: " << row;
-        return os.str();
-    }
-
-    std::string invalidColumnMessage(int col) {
-        std::ostringstream os;
-        os << "Linha invalida: " << col;
-        return os.str();
-    }
-
-    std::string colNegative(int col) {
-        std::ostringstream os;
-        os << "A linha " << col << " e negativa";
-        return os.str();
-    }
-
-    std::string rowNegative(int row) {
-        std::ostringstream os;
-        os << "A linha " << row << " e negativa";
-        return os.str();
-    }
-
-    std::string colZero() {
-        return "A coluna não pode ser zero";
-    }
-
-    std::string rowZero() {
-        return "A linha não pode ser zero";
-    }
-    
-    std::string invalidCommandMessage() {
-        return "Comando invalido! Use o comando 'help' para listar todos os comandos";
-    }
+std::string invalidRowMessage(int row) {
+  std::ostringstream os;
+  os << "Linha invalida: " << row;
+  return os.str();
 }
+
+std::string invalidColumnMessage(int col) {
+  std::ostringstream os;
+  os << "Linha invalida: " << col;
+  return os.str();
+}
+
+std::string colNegative(int col) {
+  std::ostringstream os;
+  os << "A linha " << col << " e negativa";
+  return os.str();
+}
+
+std::string rowNegative(int row) {
+  std::ostringstream os;
+  os << "A linha " << row << " e negativa";
+  return os.str();
+}
+
+std::string colZero() { return "A coluna não pode ser zero"; }
+
+std::string rowZero() { return "A linha não pode ser zero"; }
+
+std::string invalidCommandMessage() {
+  return "Comando invalido! Use o comando 'help' para listar todos os comandos";
+}
+} // namespace Messages

--- a/Src/Messages/Messages.cpp
+++ b/Src/Messages/Messages.cpp
@@ -1,42 +1,39 @@
-#ifndef MESSAGES_HPP
-#define MESSAGES_HPP
+#include "../../Includes/Messages/Messages.hpp"
 
-#include <string>
-#include <sstream>
-
-// Mensagens que são lançadas por exeptions
 namespace Messages {
-    const std::string invalidRowMessage(int row) {
+    std::string invalidRowMessage(int row) {
         std::ostringstream os;
         os << "Linha invalida: " << row;
         return os.str();
     }
 
-    const std::string invalidColumnMessage(int col) {
+    std::string invalidColumnMessage(int col) {
         std::ostringstream os;
         os << "Linha invalida: " << col;
         return os.str();
     }
 
-    const std::string colNegative(int col) {
+    std::string colNegative(int col) {
         std::ostringstream os;
         os << "A linha " << col << " e negativa";
         return os.str();
     }
 
-    const std::string rowNegative(int row) {
+    std::string rowNegative(int row) {
         std::ostringstream os;
         os << "A linha " << row << " e negativa";
         return os.str();
     }
 
-    const std::string colZero() {
+    std::string colZero() {
         return "A coluna não pode ser zero";
     }
 
-    const std::string rowZero() {
+    std::string rowZero() {
         return "A linha não pode ser zero";
     }
+    
+    std::string invalidCommandMessage() {
+        return "Comando invalido! Use o comando 'help' para listar todos os comandos";
+    }
 }
-
-#endif

--- a/Src/Utils/Validation/Validation.cpp
+++ b/Src/Utils/Validation/Validation.cpp
@@ -1,17 +1,24 @@
 #include "../../../Includes/Utils/Validation/Validation.hpp"
 
 namespace ValidationUtils {
-    void verifyRowCol(int row, int col) {
-        if (row < 0) throw InvalidRowException(Messages::rowNegative(row));
-        if (row == 0) throw InvalidRowException(Messages::rowZero());
+void verifyRowCol(int row, int col) {
+  if (row < 0)
+    throw InvalidRowException(Messages::rowNegative(row));
+  if (row == 0)
+    throw InvalidRowException(Messages::rowZero());
 
-        if (col < 0) throw InvalidColumnException(Messages::colNegative(col));
-        if (col == 0) throw InvalidColumnException(Messages::colZero());
-    }
-
-    void verifyValidRowCol(int row, int col) {
-        if (row < 0) throw InvalidRowException(Messages::invalidRowMessage(row)); // faz throw e chama mensagem de erro
-        
-        if (col < 0) throw InvalidColumnException(Messages::invalidColumnMessage(col));   
-    }
+  if (col < 0)
+    throw InvalidColumnException(Messages::colNegative(col));
+  if (col == 0)
+    throw InvalidColumnException(Messages::colZero());
 }
+
+void verifyValidRowCol(int row, int col) {
+  if (row < 0)
+    throw InvalidRowException(
+        Messages::invalidRowMessage(row)); // faz throw e chama mensagem de erro
+
+  if (col < 0)
+    throw InvalidColumnException(Messages::invalidColumnMessage(col));
+}
+} // namespace ValidationUtils


### PR DESCRIPTION
## Descrição
Refatorei a _task_ do Calebe #026 cujas modificações possuíam alguns erros que quebravam a compilação do programa.
Concertei erros de include
Adicionei os comentários
Refiz os comentários existentes em Doxygen
Formatei o código que tampouco eu havia formatado
A modularização de alguns componentes se por conta da dificuldade de compilar arquivos somente .hpp, uma vez que o _make_ não reconhece-os como modificados e é impossível definir quais objetos novos devam ser recriados

## Checklist
- [x] :cloud: **Organização**
- [x] :id: **Identidade**
- [x] :memo: **Comentários e Descrições**
- [x] :white_check_mark: **Testei Cada Parte da Funcionalidade**
- [x] :clipboard: **Padronização de Nomenclaturas**